### PR TITLE
Delete submodule properly

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ros2_laser_scan_matcher"]
-	path = ros2_laser_scan_matcher
-	url = https://github.com/EnjoyRobotics/ros2_laser_scan_matcher.git


### PR DESCRIPTION
The .gitmodules file only had the ros2_laser_scan_matcher repo as a submodule, which was deleted. The .gitmodules file should have been deleted too, so I'm deleting it now.